### PR TITLE
Added telegrams 0x0165-0x016C and 0x016F-0x0178

### DIFF
--- a/docs/ems-library.md
+++ b/docs/ems-library.md
@@ -264,6 +264,60 @@ Please contribute, content is in [Markdown](https://www.markdownguide.org/cheat-
 | 54-80 | ASCII coded numbers | 0 | 255 | 1 | ASCII | set the data that can be read with telegram 0x0001 offset 0-26|
 | 81-107 | ASCII coded numbers | 0 | 255 | 1 | ASCII | set the data that can be read with telegram 0x0001 offset 43-69|
 
+### Telegram: 0x0165, 0x0166, 0x0167, 0x0168, 0x0169, 0x016A, 0x016B, 0x016C
+
+*Name:* HMI800 holiday mode parameters  
+*Used in:* Buderus/Bosch RC300, HMC310, and similar   
+*Description:* Up to 8 hoiday periods can be defined with the above telegrams   
+*Class:* Parameter  
+*EMS category:* EMS2.0  
+*Distribution:* broadcast-on-change, unicast-write-request, unicast-on-request  
+*Offset of variables:*  
+
+| Offset | Variable name | min | max | resolution | unit | comment |
+| --- | --- | --- | --- | --- | --- | ---|
+| 0 | holiday start year | 0 | 99 | 1 | year | 0=invalid, offset 0-7 to be sent together |
+| 1 | holiday start month | 0 | 12 | 1 | month | 0=invalid, offset 0-7 to be sent together |
+| 2 | holiday start day | 0 | 31 | 1 | day | 0=invalid, offset 0-7 to be sent together |
+| 3 | holiday start time | 0 | 95 | 1 | 15 min | 0=invalid, 15 minute steps starting midnight, offset 0-7 to be sent together |
+| 4 | holiday end year | 0 | 99 | 1 | year | 0=invalid, offset 0-7 to be sent together |
+| 5 | holiday end month | 0 | 12 | 1 | month | 0=invalid, offset 0-7 to be sent together |
+| 6 | holiday end day | 0 | 31 | 1 | day | 0=invalid, offset 0-7 to be sent together |
+| 7 | holiday end time | 0 | 95 | 1 | 15 min | 0=invalid, 15 minute steps starting midnight, offset 0-7 to be sent together |
+| 8 | Holiday heating operation mode | 1 | 4 | 1 | enum | 1=auto, 2=fixed temp, 3=off, 4=eco |
+| 9 | Holiday fixed heating temp | 5 | 30 | 1 | °C ||
+| 10 | Holiday DHW operation mode | 1 | 5 | 1 | enum | 1=auto, 2=off, 3=eco, 4=low, 5=high |
+| 11 | Holioday auto thermal desinfection | -1 | 1 | 1 | bool | -1=yes, 1=no |
+| 12 | Holiday ventilation operation mode | -1 | 5 | 1 | enum | -1=time, 0=off, 1=min, 2=reduced, 3=normal, 4=max, 5=demand |
+| 13 | valid for HC1 | -1 | 1 | 1 | bool | -1=yes, 1=no |
+| 14 | valid for HC2 | -1 | 1 | 1 | bool | -1=yes, 1=no |
+| 15 | valid for HC3 | -1 | 1 | 1 | bool | -1=yes, 1=no |
+| 16 | valid for HC4 | -1 | 1 | 1 | bool | -1=yes, 1=no |
+| 17 | valid for DHW1 | -1 | 1 | 1 | bool | -1=yes, 1=no |
+| 18 | valid for DHW2 | -1 | 1 | 1 | bool | -1=yes, 1=no |
+| 19 | valid for vent1 | -1 | 1 | 1 | bool | -1=yes, 1=no |
+| 20 | valid for vent2 | -1 | 1 | 1 | bool | -1=yes, 1=no |
+| 21 | valid for vent3 | -1 | 1 | 1 | bool | -1=yes, 1=no |
+| 22 | valid for vent4 | -1 | 1 | 1 | bool | -1=yes, 1=no |
+
+### Telegram: 0x016F, 0x0170, 0x0171, 0x0172, 0x0173, 0x0174, 0x0175, 0x0176, 0x0177, 0x0178
+
+*Name:* FX100 Monitor heating circuit values  
+*Used in:* Junkers FB100/FW120 controllers   
+*Description:* Junkers monitor values of heating circuit. 10 heating circuits can be monitored   
+*Class:* Monitor  
+*EMS category:* EMS1.0  
+*Distribution:* broadcast-on-change, broadcast-periodically, unicast-on-request  
+*Offset of variables:*  
+
+| Offset | Variable name | min | max | resolution | unit | comment |
+| --- | --- | --- | --- | --- | --- | ---|
+| 0 | Heating level | 0 | 3 | 1 | enum | 0=undefined, 1=frost, 2=low, 3=high |
+| 1 | Operating mode | 0 | 5 | 1 | enum | 0=undefinde, 1=permanent, 2=auto, 3=holiday, 4=floor drying waiting, 5=floor drying running |
+| 2-3 | Requested room temperature setpoint | 0 | 300 | 0,1 | °C | |
+| 4-5 | Current internal temperature | -32768 | 32767 | 0,1 | °C | 2 byte signed int |
+| 6-7 Current external temperature | -32768 | 32767 | 0,1 | °C | 2 byte signed int |
+| 8 | Solar influence value | 0 | 50 | 1 | 0,1 | °C | |
 
 ### Telegram: 0x02A5, 0x02A6, 0x02A7, 0x02A8, 0x02A9, 0x02AA, 0x02AB, 0x02AC
 

--- a/docs/ems-library.md
+++ b/docs/ems-library.md
@@ -268,7 +268,7 @@ Please contribute, content is in [Markdown](https://www.markdownguide.org/cheat-
 
 *Name:* HMI800 holiday mode parameters  
 *Used in:* Buderus/Bosch RC300, HMC310, and similar   
-*Description:* Up to 8 hoiday periods can be defined with the above telegrams   
+*Description:* Up to 8 holiday periods can be defined with the above telegrams   
 *Class:* Parameter  
 *EMS category:* EMS2.0  
 *Distribution:* broadcast-on-change, unicast-write-request, unicast-on-request  
@@ -316,8 +316,8 @@ Please contribute, content is in [Markdown](https://www.markdownguide.org/cheat-
 | 1 | Operating mode | 0 | 5 | 1 | enum | 0=undefinde, 1=permanent, 2=auto, 3=holiday, 4=floor drying waiting, 5=floor drying running |
 | 2-3 | Requested room temperature setpoint | 0 | 300 | 0,1 | °C | |
 | 4-5 | Current internal temperature | -32768 | 32767 | 0,1 | °C | 2 byte signed int |
-| 6-7 Current external temperature | -32768 | 32767 | 0,1 | °C | 2 byte signed int |
-| 8 | Solar influence value | 0 | 50 | 1 | 0,1 | °C | |
+| 6-7 | Current external temperature | -32768 | 32767 | 0,1 | °C | 2 byte signed int |
+| 8 | Solar influence value | 0 | 50 | 0,1 | °C | |
 
 ### Telegram: 0x02A5, 0x02A6, 0x02A7, 0x02A8, 0x02A9, 0x02AA, 0x02AB, 0x02AC
 

--- a/docs/ems-library.md
+++ b/docs/ems-library.md
@@ -268,7 +268,7 @@ Please contribute, content is in [Markdown](https://www.markdownguide.org/cheat-
 
 ==The telegrams 0x0165...0016E are used in a different way in Junkers systems. See next table==  
 *Name:* HMI800 holiday mode parameters  
-*Used in:* Buderus/Bosch RC300, HMC310, and similar   
+*Used in:* Buderus/Bosch RC300, HMC310 and similar, newer Junkers controllers "Cxyz" (MY>2019)  
 *Description:* Up to 8 holiday periods can be defined with the above telegrams   
 *Class:* Parameter  
 *EMS category:* EMS2.0  
@@ -305,8 +305,8 @@ Please contribute, content is in [Markdown](https://www.markdownguide.org/cheat-
 
 ==The telegrams 0x0165...0016C are used in a different way in Buderus systems. See table before==
 This is a transscript from [hometop_HT3](https://github.com/norberts1/hometop_HT3/blob/master/HT3/sw/etc/html/HT3-Bus_Telegramme.html#26)  
-*Name:* Junkers heating circuit control  
-*Used in:* Junkers controllers   
+*Name:* Older Junkers heating circuit control  
+*Used in:* older Junkers controllers "Fxyz" (MY<2019)  
 *Description:* Up to 10 heating circuits can be controller with these telegrams. 0x0165=HC1, 0x0166=HC2, ...  
 *Class:* Parameter  
 *EMS category:* EMS1.0  

--- a/docs/ems-library.md
+++ b/docs/ems-library.md
@@ -266,6 +266,7 @@ Please contribute, content is in [Markdown](https://www.markdownguide.org/cheat-
 
 ### Telegram: 0x0165, 0x0166, 0x0167, 0x0168, 0x0169, 0x016A, 0x016B, 0x016C
 
+==The telegrams 0x0165...0016E are used in a different way in Junkers systems. See next table==  
 *Name:* HMI800 holiday mode parameters  
 *Used in:* Buderus/Bosch RC300, HMC310, and similar   
 *Description:* Up to 8 holiday periods can be defined with the above telegrams   
@@ -299,6 +300,42 @@ Please contribute, content is in [Markdown](https://www.markdownguide.org/cheat-
 | 20 | valid for vent2 | -1 | 1 | 1 | bool | -1=yes, 1=no |
 | 21 | valid for vent3 | -1 | 1 | 1 | bool | -1=yes, 1=no |
 | 22 | valid for vent4 | -1 | 1 | 1 | bool | -1=yes, 1=no |
+
+### Telegram: 0x0165, 0x0166, 0x0167, 0x0168, 0x0169, 0x016A, 0x016B, 0x016C, 0x016D, 0x016E
+
+==The telegrams 0x0165...0016C are used in a different way in Buderus systems. See table before==
+This is a transscript from [hometop_HT3](https://github.com/norberts1/hometop_HT3/blob/master/HT3/sw/etc/html/HT3-Bus_Telegramme.html#26)  
+*Name:* Junkers heating circuit control  
+*Used in:* Junkers controllers   
+*Description:* Up to 10 heating circuits can be controller with these telegrams. 0x0165=HC1, 0x0166=HC2, ...  
+*Class:* Parameter  
+*EMS category:* EMS1.0  
+*Distribution:* broadcast-on-change, unicast-write-request, unicast-on-request  
+*Offset of variables:*  
+
+| Offset | Variable name | min | max | resolution | unit | comment |
+| --- | --- | --- | --- | --- | --- | ---|
+| 0 | type of HC | 0 | 3 | 1 | enum | 0=not available, 1=unmixed HC without IPM, 2=unmixed HC with IPM, 3=mixed HC |
+| 1 | Remote controller | 0 | 2 | 1 | enum | 0=not available, 1=FB10, 2=FB100 |
+| 2 | type 2 of HC | 0 | 4 | 1 | enum | 0=undefined, 1=foot/endpoint, 2=radiators, 3=convectors, 4=floor heating |
+| 3 | foot point of heating curve | ? | ? | 1 | °C | |
+| 4 | end point of heating curve | ? | ? | 1 | °C | |
+| 5 | max flow temperature | ? | ? | 1 | °C | |
+| 6 | room influence factor | 0 | 100 | 1 | % | |
+| 7 | room influence at operation mode | 0 | 2 | 1 | enum | 0=undefined, 1=normal/eco/frost protect, 2=eco/frost protect|
+| 8 | room temperature correction | ? | ? | 1 | °C | |
+| 9 |room temperature sensor | 0 | 3 | 1 | enum | 0=undefined, 1=ext. sensor, 2=int. sensor, 3=temperature during eco |
+| 10 | frost protect | -1 | 1 | 1 | bool | -1=ON, 1=OFF |
+| 11 | stop heating at outside temp | ? | ? | 0.5 | °C | 
+| 12 | frost protection temp | ? | ? | 0.5 | °C | 
+| 13 | active heatig program | 0 | 6 | 1 | enum | 0=undefined, 1-6=heating program (1=A, 2=B, ...) |
+| 14 | operation mode HC | 0 | 4 | 1 | enum | 0=undefined, 1=frost protect, 2=eco, 3=normal, 4=auto |
+| 15 | flow temp at frost protect mode | ? | ? | 0.5 | °C ||
+| 16 | flow temp at eco mode | ? | ? | 0.5 | °C ||
+| 17 | flow temp at normal mode | ? | ? | 0.5 | °C ||
+| 18 | heat up speed | 0 | 3 | 1 | enum | 0=undefined, 1=slow, 2=normal, 3=fast |
+| 19 | holiday program | 0 | 4 | 1 | enum | 0=undefinde, 1=op mode frost protect, 2=op mode eco, 3= op mode nomral. 4=op mode auto |
+| 20 | solar influence | ? | ? | 1 | °C | |
 
 ### Telegram: 0x016F, 0x0170, 0x0171, 0x0172, 0x0173, 0x0174, 0x0175, 0x0176, 0x0177, 0x0178
 


### PR DESCRIPTION
From the discussion in #2510 and other sources.
I´m a little confused as @MichaelDvP confirmed in the above mentioned issue that 0x0165ff are holiday telegrams, but if I read thermostat.cpp line 795 the `JunkersSet` is built from that telegram. Something seems to be wrong...